### PR TITLE
Publish javadocs to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Snowizard
+Snowizard
+=========
+[![Build Status](https://travis-ci.org/generalelectric/snowizard.svg?branch=master)](https://travis-ci.org/generalelectric/snowizard)
+[![Coverage Status](https://img.shields.io/coveralls/generalelectric/snowizard.svg)](https://coveralls.io/r/generalelectric/snowizard)
+
 
 Snowizard is an HTTP-based service for generating unique ID numbers at high scale with some simple guarantees.
 
@@ -60,5 +64,3 @@ To contribute:
 ## Building
 
 To build and test, run `mvn test`.
-
-[![Build Status](https://travis-ci.org/GeneralElectric/snowizard.png)](https://travis-ci.org/GeneralElectric/snowizard)

--- a/pmd-exclude.xml
+++ b/pmd-exclude.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="snowizard-ruleset"
-    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd"
-    xsi:noNamespaceSchemaLocation="http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
-  <exclude-pattern>.*/com/ge/snowizard/api/protos/.*</exclude-pattern>
-</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,14 @@
         <tag>HEAD</tag>
     </scm>
 
+    <ciManagement>
+        <system>Travis CI</system>
+        <url>https://travis-ci.org/GeneralElectric/snowizard</url>
+    </ciManagement>
+
     <issueManagement>
         <system>github</system>
-        <url>https://github.com/GeneralElectric/snowizard/issues#issue/</url>
+        <url>https://github.com/GeneralElectric/snowizard/issues</url>
     </issueManagement>
 
     <repositories>
@@ -71,6 +76,10 @@
     </repositories>
 
     <distributionManagement>
+        <site>
+            <id>snowizard</id>
+            <url>${project.version}</url>
+        </site>
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
@@ -84,6 +93,15 @@
     </distributionManagement>
 
     <profiles>
+        <profile>
+            <id>java8-disable-strict-javadoc</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.doclint.none>-Xdoclint:none</javadoc.doclint.none>
+            </properties>
+        </profile>
         <profile>
             <id>release-sign-artifacts</id>
             <activation>
@@ -168,7 +186,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>2.3</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -191,6 +209,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
+                <configuration>
+                    <additionalparam>${javadoc.doclint.none}</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -226,11 +247,48 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.12</version>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
                 <configuration>
-                    <excludes>com/ge/snowizard/api/protos/*</excludes>
+                    <skipDeploy>true</skipDeploy>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.9</version>
+                <configuration>
+                    <path>${project.distributionManagement.site.url}</path>
+                    <message>Creating site for ${project.name} ${project.version}</message>
+                    <merge>true</merge>
+                    <noJekyll>true</noJekyll>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>site-deploy</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.1.201405082137</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>2.2.0</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -242,47 +300,6 @@
                     <onlyAnalyze>com.ge.snowizard.*</onlyAnalyze>
                     <xmlOutput>true</xmlOutput>
                     <excludeFilterFile>${basedir}/../findbugs-exclude.xml</excludeFilterFile>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <linkXref>true</linkXref>
-                    <targetJdk>1.7</targetJdk>
-                    <minimumTokens>30</minimumTokens>
-                    <rulesets>
-                        <ruleset>${basedir}/../pmd-exclude.xml</ruleset>
-                    </rulesets>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <formats>
-                        <format>xml</format>
-                    </formats>
-                    <instrumentation>
-                        <excludes>
-                            <exclude>**/*Protos.java</exclude>
-                            <exclude>**/*Test.java</exclude>
-                            <exclude>**/*IT.java</exclude>
-                            <exclude>**/Abstract*.java</exclude>
-                            <exclude>**/*Exception.java</exclude>
-                        </excludes>
-                    </instrumentation>
-                    <check>
-                        <branchRate>85</branchRate>
-                        <lineRate>85</lineRate>
-                        <haltOnFailure>false</haltOnFailure>
-                        <totalBranchRate>85</totalBranchRate>
-                        <totalLineRate>85</totalLineRate>
-                        <packageLineRate>85</packageLineRate>
-                        <packageBranchRate>85</packageBranchRate>
-                    </check>
                 </configuration>
             </plugin>
             <plugin>
@@ -305,4 +322,39 @@
             </plugin>
         </plugins>
     </build>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
+                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>index</report>
+                            <report>dependency-info</report>
+                            <report>dependencies</report>
+                            <report>issue-tracking</report>
+                            <report>scm</report>
+                            <report>license</report>
+                            <report>project-team</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <configuration>
+                    <additionalparam>${javadoc.doclint.none}</additionalparam>
+                    <show>public</show>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>


### PR DESCRIPTION
- publish javadocs to github
- use an online code coverage tool (coveralls)
- removed PMD, checkstyles and cobertura
